### PR TITLE
do not render items if the react list is hidden

### DIFF
--- a/react-list.es6
+++ b/react-list.es6
@@ -204,7 +204,16 @@ module.exports = class ReactList extends Component {
   getStartAndEnd(threshold = this.props.threshold) {
     const scroll = this.getScroll();
     const start = Math.max(0, scroll - threshold);
-    let end = scroll + this.getViewportSize() + threshold;
+
+    const viewportSize = this.getViewportSize()
+
+    // render element only if the viewportSize is greater than 0
+    if(viewportSize > 0){
+      let end = scroll + viewportSize + threshold;
+    } else {
+      let end = 0
+    }
+
     if (this.hasDeterminateSize()) {
       end = Math.min(end, this.getSpaceBefore(this.props.length));
     }
@@ -269,6 +278,10 @@ module.exports = class ReactList extends Component {
 
   updateSimpleFrame(cb) {
     const {end} = this.getStartAndEnd();
+
+    // do not update the frame if there are 0 elements to be rendered
+    if (end === 0) {return cb()}
+
     const itemEls = this.items.children;
     let elEnd = 0;
 

--- a/react-list.js
+++ b/react-list.js
@@ -289,7 +289,16 @@
 
         var scroll = this.getScroll();
         var start = Math.max(0, scroll - threshold);
-        var end = scroll + this.getViewportSize() + threshold;
+
+        var viewportSize = this.getViewportSize()
+
+        // render element only if the viewportSize is greater than 0
+        if(viewportSize > 0){
+          var end = scroll + viewportSize + threshold;
+        } else {
+          var end = 0
+        }
+
         if (this.hasDeterminateSize()) {
           end = Math.min(end, this.getSpaceBefore(this.props.length));
         }
@@ -364,6 +373,9 @@
         var _getStartAndEnd = this.getStartAndEnd(),
             end = _getStartAndEnd.end;
 
+        // do not update the frame if there are 0 elements to be rendered
+        if(end === 0) {return cb()}
+        
         var itemEls = this.items.children;
         var elEnd = 0;
 


### PR DESCRIPTION
I have some columns on the same page that uses react-list. In each one I have 200 items. Seven are visible in the portview, and 13 are rendered, I load more on scroll. 

When I open a column item in fullwidth, all the other columns are hidden (display: 'none';). Here my problem started with react-list. 

The viewport of those columns was 0 (they are hidden, remember?). and some how react-list started to render all the 200 items for every column.

The `end` was getting bigger and bigger from the threshold (`let end = scroll + this.getViewportSize() + threshold;`. react list was rendering more items are soon as there was more space)

This caused big performance issues in my app. What I've tried to achieve here is to stop react list on rendering items when it is hidden (display: 'none';).