### PR TITLE
Add useStaticScrollParent

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ A boolean to determine whether the `translate3d` CSS property should be used for
 positioning instead of the default `translate`. This can help performance on
 mobile devices, but is supported by fewer browsers.
 
+#### useStaticScrollParent (defaults to `false`)
+
+Set to `true` if the scroll parent will never change. This is an opt-in optimization that will only search for the scroll parent (or call scrollParentGetter) once for the duration of the component's life.
+
 ## Methods
 
 ##### scrollTo(index)

--- a/react-list.es6
+++ b/react-list.es6
@@ -57,7 +57,8 @@ module.exports = class ReactList extends Component {
     threshold: PropTypes.number,
     type: PropTypes.oneOf(['simple', 'variable', 'uniform']),
     useStaticSize: PropTypes.bool,
-    useTranslate3d: PropTypes.bool
+    useTranslate3d: PropTypes.bool,
+    useStaticScrollParent: PropTypes.bool
   };
 
   static defaultProps = {
@@ -70,7 +71,8 @@ module.exports = class ReactList extends Component {
     threshold: 100,
     type: 'simple',
     useStaticSize: false,
-    useTranslate3d: false
+    useTranslate3d: false,
+    useStaticScrollParent: false
   };
 
   constructor(props) {
@@ -257,6 +259,9 @@ module.exports = class ReactList extends Component {
 
   updateScrollParent() {
     const prev = this.scrollParent;
+    if (prev && this.props.useStaticScrollParent) {
+      return;
+    }
     this.scrollParent = this.getScrollParent();
     if (prev === this.scrollParent) return;
     if (prev) {

--- a/react-list.js
+++ b/react-list.js
@@ -349,6 +349,9 @@
       key: 'updateScrollParent',
       value: function updateScrollParent() {
         var prev = this.scrollParent;
+        if (prev && this.props.useStaticScrollParent) {
+          return;
+        }
         this.scrollParent = this.getScrollParent();
         if (prev === this.scrollParent) return;
         if (prev) {
@@ -660,7 +663,8 @@
     threshold: _propTypes2.default.number,
     type: _propTypes2.default.oneOf(['simple', 'variable', 'uniform']),
     useStaticSize: _propTypes2.default.bool,
-    useTranslate3d: _propTypes2.default.bool
+    useTranslate3d: _propTypes2.default.bool,
+    useStaticScrollParent: _propTypes2.default.bool
   }, _class.defaultProps = {
     axis: 'y',
     itemRenderer: function itemRenderer(index, key) {
@@ -683,6 +687,7 @@
     threshold: 100,
     type: 'simple',
     useStaticSize: false,
-    useTranslate3d: false
+    useTranslate3d: false,
+    useStaticScrollParent: false
   }, _temp);
 });


### PR DESCRIPTION
Hey there!

Our team is currently using react-list for a project. In the process of doing some performance fixes, I noticed an unusually large chunk of time being spent in scroll events, even with a very simple item render function. Digging deeper through some performance profiling in our app, I found that a large amount of this time was spent calculating styles - specifically, `window.getComputedStyle` (about 70-80% of the frame).

Our app has a decently large tree between the list component and the scroll parent, with quite a few styles applied. While we could probably resolve this by using the `scrollParentGetter` and caching the result ourselves, allowing an option to cache the scroll parent in the component saves a lot of duplicated logic, and design-wise didn't seem too far from the norm. In addition, the current implementation could be used in conjunction with `scrollParentGetter`, and that function would be invoked only once, with the result cached during the component's lifetime.

The option is disabled by default to maintain backwards compatibility.

Let me know if this would be useful, happy to discuss.