### PR TITLE
dev(makefile): add 'make build' by default and depend on package.json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
 BIN=node_modules/.bin/
 COGS=$(BIN)cogs
+.DEFAULT_GOAL := build
 
-dev:
+install: package.json
 	npm install
+
+build: install
+	$(COGS)
+
+dev: install
 	$(COGS) -w docs/index.es6 -w react-list.es6


### PR DESCRIPTION
Avoids unnecessary npm install on each build or dev invocation.

Do you want to start including `package-lock.json`?