### PR TITLE
feat(layout): add scrollParentViewportSizeGetter

### DIFF
--- a/react-list.es6
+++ b/react-list.es6
@@ -40,6 +40,26 @@ const isEqualSubset = (a, b) => {
   return true;
 };
 
+const defaultScrollParentGetter = (component) => {
+  const {axis} = component.props;
+  let el = component.getEl();
+  const overflowKey = OVERFLOW_KEYS[axis];
+  while (el = el.parentElement) {
+    switch (window.getComputedStyle(el)[overflowKey]) {
+    case 'auto': case 'scroll': case 'overlay': return el;
+    }
+  }
+  return window;
+};
+
+const defaultScrollParentViewportSizeGetter = (component) => {
+  const {axis} = component.props;
+  const {scrollParent} = component;
+  return scrollParent === window ?
+    window[INNER_SIZE_KEYS[axis]] :
+    scrollParent[CLIENT_SIZE_KEYS[axis]];
+};
+
 module.exports = class ReactList extends Component {
   static displayName = 'ReactList';
 
@@ -54,6 +74,7 @@ module.exports = class ReactList extends Component {
     minSize: PropTypes.number,
     pageSize: PropTypes.number,
     scrollParentGetter: PropTypes.func,
+    scrollParentViewportSizeGetter: PropTypes.func,
     threshold: PropTypes.number,
     type: PropTypes.oneOf(['simple', 'variable', 'uniform']),
     useStaticSize: PropTypes.bool,
@@ -67,6 +88,8 @@ module.exports = class ReactList extends Component {
     length: 0,
     minSize: 1,
     pageSize: 10,
+    scrollParentGetter: defaultScrollParentGetter,
+    scrollParentViewportSizeGetter: defaultScrollParentViewportSizeGetter,
     threshold: 100,
     type: 'simple',
     useStaticSize: false,
@@ -80,13 +103,15 @@ module.exports = class ReactList extends Component {
     const {from, size} = this.constrain(initialIndex, 0, itemsPerRow, props);
     this.state = {from, size, itemsPerRow};
     this.cache = {};
-    this.cachedScroll = null;
+    this.cachedScrollPosition = null;
     this.prevPrevState = {};
     this.unstable = false;
     this.updateCounter = 0;
   }
 
   componentWillReceiveProps(next) {
+    // Viewport scroll is no longer useful if axis changes
+    if (this.props.axis !== next.axis) this.clearSizeCache();
     let {from, size, itemsPerRow} = this.state;
     this.maybeSetState(this.constrain(from, size, itemsPerRow, next), NOOP);
   }
@@ -141,22 +166,9 @@ module.exports = class ReactList extends Component {
     return this.el || this.items;
   }
 
-  getScrollParent() {
-    const {axis, scrollParentGetter} = this.props;
-    if (scrollParentGetter) return scrollParentGetter();
-    let el = this.getEl();
-    const overflowKey = OVERFLOW_KEYS[axis];
-    while (el = el.parentElement) {
-      switch (window.getComputedStyle(el)[overflowKey]) {
-      case 'auto': case 'scroll': case 'overlay': return el;
-      }
-    }
-    return window;
-  }
-
-  getScroll() {
+  getScrollPosition() {
     // Cache scroll position as this causes a forced synchronous layout.
-    if (typeof this.cachedScroll === 'number') return this.cachedScroll;
+    if (typeof this.cachedScrollPosition === 'number') return this.cachedScrollPosition;
     const {scrollParent} = this;
     const {axis} = this.props;
     const scrollKey = SCROLL_START_KEYS[axis];
@@ -166,11 +178,11 @@ module.exports = class ReactList extends Component {
       // whichever has a value.
       document.body[scrollKey] || document.documentElement[scrollKey] :
       scrollParent[scrollKey];
-    const max = this.getScrollSize() - this.getViewportSize();
+    const max = this.getScrollSize() - this.props.scrollParentViewportSizeGetter(this);
     const scroll = Math.max(0, Math.min(actual, max));
     const el = this.getEl();
-    this.cachedScroll = this.getOffset(scrollParent) + scroll - this.getOffset(el);
-    return this.cachedScroll;
+    this.cachedScrollPosition = this.getOffset(scrollParent) + scroll - this.getOffset(el);
+    return this.cachedScrollPosition;
   }
 
   setScroll(offset) {
@@ -181,14 +193,6 @@ module.exports = class ReactList extends Component {
 
     offset -= this.getOffset(this.scrollParent);
     scrollParent[SCROLL_START_KEYS[axis]] = offset;
-  }
-
-  getViewportSize() {
-    const {scrollParent} = this;
-    const {axis} = this.props;
-    return scrollParent === window ?
-      window[INNER_SIZE_KEYS[axis]] :
-      scrollParent[CLIENT_SIZE_KEYS[axis]];
   }
 
   getScrollSize() {
@@ -206,9 +210,9 @@ module.exports = class ReactList extends Component {
   }
 
   getStartAndEnd(threshold = this.props.threshold) {
-    const scroll = this.getScroll();
+    const scroll = this.getScrollPosition();
     const start = Math.max(0, scroll - threshold);
-    let end = scroll + this.getViewportSize() + threshold;
+    let end = scroll + this.props.scrollParentViewportSizeGetter(this) + threshold;
     if (this.hasDeterminateSize()) {
       end = Math.min(end, this.getSpaceBefore(this.props.length));
     }
@@ -249,9 +253,13 @@ module.exports = class ReactList extends Component {
     return {itemSize, itemsPerRow};
   }
 
+  clearSizeCache() {
+    this.cachedScrollPosition = null;
+  }
+
   // Called by 'scroll' and 'resize' events, clears scroll position cache.
   updateFrameAndClearCache(cb) {
-    this.cachedScroll = null;
+    this.clearSizeCache();
     return this.updateFrame(cb);
   }
 
@@ -267,12 +275,14 @@ module.exports = class ReactList extends Component {
 
   updateScrollParent() {
     const prev = this.scrollParent;
-    this.scrollParent = this.getScrollParent();
+    this.scrollParent = this.props.scrollParentGetter(this);
     if (prev === this.scrollParent) return;
     if (prev) {
       prev.removeEventListener('scroll', this.updateFrameAndClearCache);
       prev.removeEventListener('mousewheel', NOOP);
     }
+    // If we have a new parent, cached parent dimensions are no longer useful.
+    this.clearSizeCache();
     this.scrollParent.addEventListener('scroll', this.updateFrameAndClearCache, PASSIVE);
     // You have to attach mousewheel listener to the scrollable element.
     // Just an empty listener. After that onscroll events will be fired synchronously.
@@ -310,7 +320,7 @@ module.exports = class ReactList extends Component {
     const maxFrom = length - 1;
 
     while (from < maxFrom) {
-      const itemSize = this.getSizeOf(from);
+      const itemSize = this.getSizeOfItem(from);
       if (itemSize == null || space + itemSize > start) break;
       space += itemSize;
       ++from;
@@ -319,7 +329,7 @@ module.exports = class ReactList extends Component {
     const maxSize = length - from;
 
     while (size < maxSize && space < end) {
-      const itemSize = this.getSizeOf(from + size);
+      const itemSize = this.getSizeOfItem(from + size);
       if (itemSize == null) {
         size = Math.min(size + pageSize, maxSize);
         break;
@@ -365,7 +375,7 @@ module.exports = class ReactList extends Component {
     let space = cache[from] || 0;
     for (let i = from; i < index; ++i) {
       cache[i] = space;
-      const itemSize = this.getSizeOf(i);
+      const itemSize = this.getSizeOfItem(i);
       if (itemSize == null) break;
       space += itemSize;
     }
@@ -383,7 +393,7 @@ module.exports = class ReactList extends Component {
     }
   }
 
-  getSizeOf(index) {
+  getSizeOfItem(index) {
     const {cache, items} = this;
     const {axis, itemSizeGetter, itemSizeEstimator, type} = this.props;
     const {from, itemSize, size} = this.state;
@@ -429,9 +439,9 @@ module.exports = class ReactList extends Component {
   }
 
   scrollAround(index) {
-    const current = this.getScroll();
+    const current = this.getScrollPosition();
     const bottom = this.getSpaceBefore(index);
-    const top = bottom - this.getViewportSize() + this.getSizeOf(index);
+    const top = bottom - this.props.scrollParentViewportSizeGetter(this) + this.getSizeOfItem(index);
     const min = Math.min(top, bottom);
     const max = Math.max(top, bottom);
     if (current <= min) return this.setScroll(min);
@@ -445,7 +455,7 @@ module.exports = class ReactList extends Component {
     let first, last;
     for (let i = from; i < from + size; ++i) {
       const itemStart = this.getSpaceBefore(i, cache);
-      const itemEnd = itemStart + this.getSizeOf(i);
+      const itemEnd = itemStart + this.getSizeOfItem(i);
       if (first == null && itemEnd > start) first = i;
       if (first != null && itemStart < end) last = i;
     }

--- a/react-list.js
+++ b/react-list.js
@@ -113,6 +113,27 @@
     }return true;
   };
 
+  var defaultScrollParentGetter = function defaultScrollParentGetter(component) {
+    var axis = component.props.axis;
+
+    var el = component.getEl();
+    var overflowKey = OVERFLOW_KEYS[axis];
+    while (el = el.parentElement) {
+      switch (window.getComputedStyle(el)[overflowKey]) {
+        case 'auto':case 'scroll':case 'overlay':
+          return el;
+      }
+    }
+    return window;
+  };
+
+  var defaultScrollParentViewportSizeGetter = function defaultScrollParentViewportSizeGetter(component) {
+    var axis = component.props.axis;
+    var scrollParent = component.scrollParent;
+
+    return scrollParent === window ? window[INNER_SIZE_KEYS[axis]] : scrollParent[CLIENT_SIZE_KEYS[axis]];
+  };
+
   _module3.default.exports = (_temp = _class = function (_Component) {
     _inherits(ReactList, _Component);
 
@@ -131,7 +152,7 @@
 
       _this.state = { from: from, size: size, itemsPerRow: itemsPerRow };
       _this.cache = {};
-      _this.cachedScroll = null;
+      _this.cachedScrollPosition = null;
       _this.prevPrevState = {};
       _this.unstable = false;
       _this.updateCounter = 0;
@@ -141,6 +162,8 @@
     _createClass(ReactList, [{
       key: 'componentWillReceiveProps',
       value: function componentWillReceiveProps(next) {
+        // Viewport scroll is no longer useful if axis changes
+        if (this.props.axis !== next.axis) this.clearSizeCache();
         var _state = this.state,
             from = _state.from,
             size = _state.size,
@@ -209,28 +232,10 @@
         return this.el || this.items;
       }
     }, {
-      key: 'getScrollParent',
-      value: function getScrollParent() {
-        var _props = this.props,
-            axis = _props.axis,
-            scrollParentGetter = _props.scrollParentGetter;
-
-        if (scrollParentGetter) return scrollParentGetter();
-        var el = this.getEl();
-        var overflowKey = OVERFLOW_KEYS[axis];
-        while (el = el.parentElement) {
-          switch (window.getComputedStyle(el)[overflowKey]) {
-            case 'auto':case 'scroll':case 'overlay':
-              return el;
-          }
-        }
-        return window;
-      }
-    }, {
-      key: 'getScroll',
-      value: function getScroll() {
+      key: 'getScrollPosition',
+      value: function getScrollPosition() {
         // Cache scroll position as this causes a forced synchronous layout.
-        if (typeof this.cachedScroll === 'number') return this.cachedScroll;
+        if (typeof this.cachedScrollPosition === 'number') return this.cachedScrollPosition;
         var scrollParent = this.scrollParent;
         var axis = this.props.axis;
 
@@ -240,11 +245,11 @@
         // always return document.documentElement[scrollKey] as 0, so take
         // whichever has a value.
         document.body[scrollKey] || document.documentElement[scrollKey] : scrollParent[scrollKey];
-        var max = this.getScrollSize() - this.getViewportSize();
+        var max = this.getScrollSize() - this.props.scrollParentViewportSizeGetter(this);
         var scroll = Math.max(0, Math.min(actual, max));
         var el = this.getEl();
-        this.cachedScroll = this.getOffset(scrollParent) + scroll - this.getOffset(el);
-        return this.cachedScroll;
+        this.cachedScrollPosition = this.getOffset(scrollParent) + scroll - this.getOffset(el);
+        return this.cachedScrollPosition;
       }
     }, {
       key: 'setScroll',
@@ -257,14 +262,6 @@
 
         offset -= this.getOffset(this.scrollParent);
         scrollParent[SCROLL_START_KEYS[axis]] = offset;
-      }
-    }, {
-      key: 'getViewportSize',
-      value: function getViewportSize() {
-        var scrollParent = this.scrollParent;
-        var axis = this.props.axis;
-
-        return scrollParent === window ? window[INNER_SIZE_KEYS[axis]] : scrollParent[CLIENT_SIZE_KEYS[axis]];
       }
     }, {
       key: 'getScrollSize',
@@ -280,9 +277,9 @@
     }, {
       key: 'hasDeterminateSize',
       value: function hasDeterminateSize() {
-        var _props2 = this.props,
-            itemSizeGetter = _props2.itemSizeGetter,
-            type = _props2.type;
+        var _props = this.props,
+            itemSizeGetter = _props.itemSizeGetter,
+            type = _props.type;
 
         return type === 'uniform' || itemSizeGetter;
       }
@@ -291,9 +288,9 @@
       value: function getStartAndEnd() {
         var threshold = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : this.props.threshold;
 
-        var scroll = this.getScroll();
+        var scroll = this.getScrollPosition();
         var start = Math.max(0, scroll - threshold);
-        var end = scroll + this.getViewportSize() + threshold;
+        var end = scroll + this.props.scrollParentViewportSizeGetter(this) + threshold;
         if (this.hasDeterminateSize()) {
           end = Math.min(end, this.getSpaceBefore(this.props.length));
         }
@@ -302,9 +299,9 @@
     }, {
       key: 'getItemSizeAndItemsPerRow',
       value: function getItemSizeAndItemsPerRow() {
-        var _props3 = this.props,
-            axis = _props3.axis,
-            useStaticSize = _props3.useStaticSize;
+        var _props2 = this.props,
+            axis = _props2.axis,
+            useStaticSize = _props2.useStaticSize;
         var _state2 = this.state,
             itemSize = _state2.itemSize,
             itemsPerRow = _state2.itemsPerRow;
@@ -336,9 +333,14 @@
         }return { itemSize: itemSize, itemsPerRow: itemsPerRow };
       }
     }, {
+      key: 'clearSizeCache',
+      value: function clearSizeCache() {
+        this.cachedScrollPosition = null;
+      }
+    }, {
       key: 'updateFrameAndClearCache',
       value: function updateFrameAndClearCache(cb) {
-        this.cachedScroll = null;
+        this.clearSizeCache();
         return this.updateFrame(cb);
       }
     }, {
@@ -359,12 +361,14 @@
       key: 'updateScrollParent',
       value: function updateScrollParent() {
         var prev = this.scrollParent;
-        this.scrollParent = this.getScrollParent();
+        this.scrollParent = this.props.scrollParentGetter(this);
         if (prev === this.scrollParent) return;
         if (prev) {
           prev.removeEventListener('scroll', this.updateFrameAndClearCache);
           prev.removeEventListener('mousewheel', NOOP);
         }
+        // If we have a new parent, cached parent dimensions are no longer useful.
+        this.clearSizeCache();
         this.scrollParent.addEventListener('scroll', this.updateFrameAndClearCache, PASSIVE);
         // You have to attach mousewheel listener to the scrollable element.
         // Just an empty listener. After that onscroll events will be fired synchronously.
@@ -389,9 +393,9 @@
 
         if (elEnd > end) return cb();
 
-        var _props4 = this.props,
-            pageSize = _props4.pageSize,
-            length = _props4.length;
+        var _props3 = this.props,
+            pageSize = _props3.pageSize,
+            length = _props3.length;
 
         var size = Math.min(this.state.size + pageSize, length);
         this.maybeSetState({ size: size }, cb);
@@ -405,9 +409,9 @@
             start = _getStartAndEnd2.start,
             end = _getStartAndEnd2.end;
 
-        var _props5 = this.props,
-            length = _props5.length,
-            pageSize = _props5.pageSize;
+        var _props4 = this.props,
+            length = _props4.length,
+            pageSize = _props4.pageSize;
 
         var space = 0;
         var from = 0;
@@ -415,7 +419,7 @@
         var maxFrom = length - 1;
 
         while (from < maxFrom) {
-          var itemSize = this.getSizeOf(from);
+          var itemSize = this.getSizeOfRow(from);
           if (itemSize == null || space + itemSize > start) break;
           space += itemSize;
           ++from;
@@ -424,7 +428,7 @@
         var maxSize = length - from;
 
         while (size < maxSize && space < end) {
-          var _itemSize = this.getSizeOf(from + size);
+          var _itemSize = this.getSizeOfRow(from + size);
           if (_itemSize == null) {
             size = Math.min(size + pageSize, maxSize);
             break;
@@ -478,7 +482,7 @@
         var space = cache[from] || 0;
         for (var i = from; i < index; ++i) {
           cache[i] = space;
-          var _itemSize2 = this.getSizeOf(i);
+          var _itemSize2 = this.getSizeOfRow(i);
           if (_itemSize2 == null) break;
           space += _itemSize2;
         }
@@ -498,15 +502,15 @@
         }
       }
     }, {
-      key: 'getSizeOf',
-      value: function getSizeOf(index) {
+      key: 'getSizeOfRow',
+      value: function getSizeOfRow(index) {
         var cache = this.cache,
             items = this.items;
-        var _props6 = this.props,
-            axis = _props6.axis,
-            itemSizeGetter = _props6.itemSizeGetter,
-            itemSizeEstimator = _props6.itemSizeEstimator,
-            type = _props6.type;
+        var _props5 = this.props,
+            axis = _props5.axis,
+            itemSizeGetter = _props5.itemSizeGetter,
+            itemSizeEstimator = _props5.itemSizeEstimator,
+            type = _props5.type;
         var _state4 = this.state,
             from = _state4.from,
             itemSize = _state4.itemSize,
@@ -559,9 +563,9 @@
     }, {
       key: 'scrollAround',
       value: function scrollAround(index) {
-        var current = this.getScroll();
+        var current = this.getScrollPosition();
         var bottom = this.getSpaceBefore(index);
-        var top = bottom - this.getViewportSize() + this.getSizeOf(index);
+        var top = bottom - this.props.scrollParentViewportSizeGetter(this) + this.getSizeOfRow(index);
         var min = Math.min(top, bottom);
         var max = Math.max(top, bottom);
         if (current <= min) return this.setScroll(min);
@@ -583,7 +587,7 @@
             last = void 0;
         for (var i = from; i < from + size; ++i) {
           var itemStart = this.getSpaceBefore(i, cache);
-          var itemEnd = itemStart + this.getSizeOf(i);
+          var itemEnd = itemStart + this.getSizeOfRow(i);
           if (first == null && itemEnd > start) first = i;
           if (first != null && itemStart < end) last = i;
         }
@@ -594,9 +598,9 @@
       value: function renderItems() {
         var _this3 = this;
 
-        var _props7 = this.props,
-            itemRenderer = _props7.itemRenderer,
-            itemsRenderer = _props7.itemsRenderer;
+        var _props6 = this.props,
+            itemRenderer = _props6.itemRenderer,
+            itemsRenderer = _props6.itemsRenderer;
         var _state6 = this.state,
             from = _state6.from,
             size = _state6.size;
@@ -613,11 +617,11 @@
       value: function render() {
         var _this4 = this;
 
-        var _props8 = this.props,
-            axis = _props8.axis,
-            length = _props8.length,
-            type = _props8.type,
-            useTranslate3d = _props8.useTranslate3d;
+        var _props7 = this.props,
+            axis = _props7.axis,
+            length = _props7.length,
+            type = _props7.type,
+            useTranslate3d = _props7.useTranslate3d;
         var _state7 = this.state,
             from = _state7.from,
             itemsPerRow = _state7.itemsPerRow;
@@ -669,6 +673,7 @@
     minSize: _propTypes2.default.number,
     pageSize: _propTypes2.default.number,
     scrollParentGetter: _propTypes2.default.func,
+    scrollParentViewportSizeGetter: _propTypes2.default.func,
     threshold: _propTypes2.default.number,
     type: _propTypes2.default.oneOf(['simple', 'variable', 'uniform']),
     useStaticSize: _propTypes2.default.bool,
@@ -692,6 +697,8 @@
     length: 0,
     minSize: 1,
     pageSize: 10,
+    scrollParentGetter: defaultScrollParentGetter,
+    scrollParentViewportSizeGetter: defaultScrollParentViewportSizeGetter,
     threshold: 100,
     type: 'simple',
     useStaticSize: false,


### PR DESCRIPTION
Got another one for you. As per [Paul Irish's list of synchronous reflow triggers](https://gist.github.com/paulirish/5d52fb081b3570c81e3a#window), hitting `window.inner*` will cause a forced synchronous reflow. I'm seeing the last cause now gone in our app (scroll position) but this is still causing it. 

Unfortunately, we can't just add another cached number here, because we won't be able to invalidate it if the scrollParent actually changes size on its own (imagine a dashboard / grid layout with resizable widgets). So I figure this sort of thing is really best left to the application, and we move to default `*Getter` implementations.

Some of the noise in this diff is renaming of functions I found confusingly terse. I've also moved the default implementation of `getScrollParent` and `getViewportSize` into `defaultProps` so we don't have to branch on their existence anymore.

If you're okay with the direction I'll update the README for the new prop. There's nothing breaking in here, but there is a bugfix on L284.