### PR TITLE
Fix itemRenderer key value

### DIFF
--- a/react-list.es6
+++ b/react-list.es6
@@ -466,7 +466,10 @@ module.exports = class ReactList extends Component {
     const {itemRenderer, itemsRenderer} = this.props;
     const {from, size} = this.state;
     const items = [];
-    for (let i = 0; i < size; ++i) items.push(itemRenderer(from + i, i));
+    for (let i = 0; i < size; ++i) {
+      const index = from + i;
+      items.push(itemRenderer(index, index));
+    }
     return itemsRenderer(items, c => this.items = c);
   }
 


### PR DESCRIPTION
When calling itemRenderer(index, key) key argument should be equal to index in order to improve performance by avoiding unnecessary components remounts/renders between rows on scrolling.

Right now key is always started from 0 and incremented by 1 for the different slices of list items which is wrong.

Because of this issue In my project I have to use index as a key value:
`const itemRenderer = index => (<div key={index}>{someList[index]}</div>);`