### PR TITLE
Change MAX_SYNC_UPDATES to 50

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -20590,7 +20590,7 @@ Cogs.define("react-list.js", function (COGS_REQUIRE, COGS_REQUIRE_ASYNC, module,
   }() ? { passive: true } : false;
 
   var UNSTABLE_MESSAGE = 'ReactList failed to reach a stable state.';
-  var MAX_SYNC_UPDATES = 100;
+  var MAX_SYNC_UPDATES = 50;
 
   var isEqualSubset = function isEqualSubset(a, b) {
     for (var key in b) {

--- a/react-list.es6
+++ b/react-list.es6
@@ -32,7 +32,7 @@ const PASSIVE = (() => {
 })() ? {passive: true} : false;
 
 const UNSTABLE_MESSAGE = 'ReactList failed to reach a stable state.';
-const MAX_SYNC_UPDATES = 100;
+const MAX_SYNC_UPDATES = 50;
 
 const isEqualSubset = (a, b) => {
   for (let key in b) if (a[key] !== b[key]) return false;

--- a/react-list.js
+++ b/react-list.js
@@ -105,7 +105,7 @@
   }() ? { passive: true } : false;
 
   var UNSTABLE_MESSAGE = 'ReactList failed to reach a stable state.';
-  var MAX_SYNC_UPDATES = 100;
+  var MAX_SYNC_UPDATES = 50;
 
   var isEqualSubset = function isEqualSubset(a, b) {
     for (var key in b) {


### PR DESCRIPTION
In React v16, NESTED_UPDATE_LIMIT is now 50, so the unstable list is not being caught.