### PR TITLE
[issue-179] Fix getVisibleRange for incomplete rows/columns

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -20777,7 +20777,11 @@ Cogs.define("react-list.js", function (COGS_REQUIRE, COGS_REQUIRE_ASYNC, module,
         var start = Math.max(0, scroll - threshold);
         var end = scroll + this.props.scrollParentViewportSizeGetter(this) + threshold;
         if (this.hasDeterminateSize()) {
-          end = Math.min(end, this.getSpaceBefore(this.props.length));
+          var _getItemSizeAndItemsP = this.getItemSizeAndItemsPerRow(),
+              itemSize = _getItemSizeAndItemsP.itemSize;
+
+          var maxLength = this.getSpaceBefore(this.props.length - 1) + itemSize;
+          end = Math.min(end, maxLength);
         }
         return { start: start, end: end };
       }
@@ -20927,9 +20931,9 @@ Cogs.define("react-list.js", function (COGS_REQUIRE, COGS_REQUIRE_ASYNC, module,
     }, {
       key: 'updateUniformFrame',
       value: function updateUniformFrame(cb) {
-        var _getItemSizeAndItemsP = this.getItemSizeAndItemsPerRow(),
-            itemSize = _getItemSizeAndItemsP.itemSize,
-            itemsPerRow = _getItemSizeAndItemsP.itemsPerRow;
+        var _getItemSizeAndItemsP2 = this.getItemSizeAndItemsPerRow(),
+            itemSize = _getItemSizeAndItemsP2.itemSize,
+            itemsPerRow = _getItemSizeAndItemsP2.itemsPerRow;
 
         if (!itemSize || !itemsPerRow) return cb();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-list",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/react-list.es6
+++ b/react-list.es6
@@ -12,7 +12,7 @@ const SCROLL_SIZE_KEYS = {x: 'scrollWidth', y: 'scrollHeight'};
 const SCROLL_START_KEYS = {x: 'scrollLeft', y: 'scrollTop'};
 const SIZE_KEYS = {x: 'width', y: 'height'};
 
-const NOOP = () => {};
+const NOOP = () => { };
 
 // If a browser doesn't support the `options` argument to
 // add/removeEventListener, we need to check, otherwise we will
@@ -27,7 +27,7 @@ const PASSIVE = (() => {
         return false;
       }
     });
-  } catch (e) {}
+  } catch (e) { }
   return hasSupport;
 })() ? {passive: true} : false;
 
@@ -214,7 +214,9 @@ module.exports = class ReactList extends Component {
     const start = Math.max(0, scroll - threshold);
     let end = scroll + this.props.scrollParentViewportSizeGetter(this) + threshold;
     if (this.hasDeterminateSize()) {
-      end = Math.min(end, this.getSpaceBefore(this.props.length));
+      const {itemSize} = this.getItemSizeAndItemsPerRow();
+      const maxLength = this.getSpaceBefore(this.props.length - 1) + itemSize;
+      end = Math.min(end, maxLength);
     }
     return {start, end};
   }
@@ -248,7 +250,7 @@ module.exports = class ReactList extends Component {
       let item = itemEls[itemsPerRow];
       item && item[startKey] === firstStart;
       item = itemEls[itemsPerRow]
-    ) ++itemsPerRow;
+    )++itemsPerRow;
 
     return {itemSize, itemsPerRow};
   }
@@ -424,7 +426,7 @@ module.exports = class ReactList extends Component {
     if (size > length) size = length;
     from =
       type === 'simple' || !from ? 0 :
-      Math.max(Math.min(from, length - size), 0);
+        Math.max(Math.min(from, length - size), 0);
 
     if (mod = from % itemsPerRow) {
       from -= mod;
@@ -490,8 +492,8 @@ module.exports = class ReactList extends Component {
     const y = axis === 'y' ? offset : 0;
     const transform =
       useTranslate3d ?
-      `translate3d(${x}px, ${y}px, 0)` :
-      `translate(${x}px, ${y}px)`;
+        `translate3d(${x}px, ${y}px, 0)` :
+        `translate(${x}px, ${y}px)`;
     const listStyle = {
       msTransform: transform,
       WebkitTransform: transform,

--- a/react-list.js
+++ b/react-list.js
@@ -292,7 +292,11 @@
         var start = Math.max(0, scroll - threshold);
         var end = scroll + this.props.scrollParentViewportSizeGetter(this) + threshold;
         if (this.hasDeterminateSize()) {
-          end = Math.min(end, this.getSpaceBefore(this.props.length));
+          var _getItemSizeAndItemsP = this.getItemSizeAndItemsPerRow(),
+              itemSize = _getItemSizeAndItemsP.itemSize;
+
+          var maxLength = this.getSpaceBefore(this.props.length - 1) + itemSize;
+          end = Math.min(end, maxLength);
         }
         return { start: start, end: end };
       }
@@ -442,9 +446,9 @@
     }, {
       key: 'updateUniformFrame',
       value: function updateUniformFrame(cb) {
-        var _getItemSizeAndItemsP = this.getItemSizeAndItemsPerRow(),
-            itemSize = _getItemSizeAndItemsP.itemSize,
-            itemsPerRow = _getItemSizeAndItemsP.itemsPerRow;
+        var _getItemSizeAndItemsP2 = this.getItemSizeAndItemsPerRow(),
+            itemSize = _getItemSizeAndItemsP2.itemSize,
+            itemsPerRow = _getItemSizeAndItemsP2.itemsPerRow;
 
         if (!itemSize || !itemsPerRow) return cb();
 


### PR DESCRIPTION
Co-authored-by: Jamie Maher <James.maher@sky.uk>

https://github.com/coderiety/react-list/issues/179

The main fix was to call `getSpaceBefore` with the last item index instead of `index + 1`.
The previous implementation worked for full rows because it assumed there was always an extra (virtual) row.
