### PR TITLE
Change MAX_SYNC_UPDATES to 40

### DIFF
--- a/react-list.es6
+++ b/react-list.es6
@@ -35,7 +35,7 @@ const PASSIVE = (() => {
   : false;
 
 const UNSTABLE_MESSAGE = 'ReactList failed to reach a stable state.';
-const MAX_SYNC_UPDATES = 50;
+const MAX_SYNC_UPDATES = 40;
 
 const isEqualSubset = (a, b) => {
   for (const key in b) if (a[key] !== b[key]) return false;


### PR DESCRIPTION
In some case, the limit of 50 was not low enough and the React error "Invariant Violation: Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops." could appear.

Seen on iOS Cordova app using WKWebView, when app relaunched after being killed.
The updateCounter variable set to 48 before React throw the error.
No reproductible on Chrome or Safari Mac.

```
[Log] componentDidUpdate – 45 (cordova.js, line 1731)
[Log] componentDidUpdate – 46 (cordova.js, line 1731)
[Log] componentDidUpdate – 47 (cordova.js, line 1731)
[Log] componentDidUpdate – 48 (cordova.js, line 1731)
[Error] Invariant Violation: Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.
	invariant (react-dom.development.js:55)
	scheduleWork (react-dom.development.js:19870)
	enqueueSetState (react-dom.development.js:11144)
	setState (react.development.js:335)
	maybeSetState (react-list.js:212)
	updateVariableFrame (react-list.js:444)
	componentDidUpdate (react-list.js:205)
```