### PR TITLE
Fix operation in strict mode

### DIFF
--- a/docs/index.js
+++ b/docs/index.js
@@ -34861,6 +34861,7 @@ Cogs.define("react-list.js", function (COGS_REQUIRE, COGS_REQUIRE_ASYNC, module,
         window.removeEventListener('resize', this.updateFrameAndClearCache);
         this.scrollParent.removeEventListener('scroll', this.updateFrameAndClearCache, PASSIVE);
         this.scrollParent.removeEventListener('mousewheel', NOOP, PASSIVE);
+        this.scrollParent = null; // Important to ensure proper setup on second mount in StrictMode
       }
     }, {
       key: "getOffset",

--- a/react-list.es6
+++ b/react-list.es6
@@ -183,6 +183,7 @@ module.exports = class ReactList extends Component {
       PASSIVE
     );
     this.scrollParent.removeEventListener('mousewheel', NOOP, PASSIVE);
+    this.scrollParent = null; // Important to ensure proper setup on second mount in StrictMode
   }
 
   getOffset(el) {

--- a/react-list.js
+++ b/react-list.js
@@ -247,6 +247,7 @@
         window.removeEventListener('resize', this.updateFrameAndClearCache);
         this.scrollParent.removeEventListener('scroll', this.updateFrameAndClearCache, PASSIVE);
         this.scrollParent.removeEventListener('mousewheel', NOOP, PASSIVE);
+        this.scrollParent = null; // Important to ensure proper setup on second mount in StrictMode
       }
     }, {
       key: "getOffset",


### PR DESCRIPTION
We were struggling with using ReactList with strict mode in our application.

The problem seems to be that the listeners on the scroll parents are removed but this.scrollParent remains set.
This means that on the second mount strict mode does, updateScrollParent will not add the required listeners.

Setting scrollParent to null on unmount resolves this problem.
